### PR TITLE
Renamed plugin into `unito.streamflow`

### DIFF
--- a/postgresql/plugin.py
+++ b/postgresql/plugin.py
@@ -5,4 +5,4 @@ from postgresql.database import PostgreSQLDatabase
 
 class PostgreSQLStreamFlowPlugin(StreamFlowPlugin):
     def register(self) -> None:
-        self.register_database("postgresql", PostgreSQLDatabase)
+        self.register_database("unito.postgresql", PostgreSQLDatabase)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ Package = "https://pypi.org/project/streamflow-postgresql"
 Repository = "https://github.com/alpha-unito/streamflow-postgresql"
 
 [project.entry-points]
-"unito.streamflow.plugin" = {postgresql = "postgresql.plugin:PostgreSQLStreamFlowPlugin"}
+"unito.streamflow.plugin" = {"unito.postgresql" = "postgresql.plugin:PostgreSQLStreamFlowPlugin"}
 
 
 [tool.setuptools]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,7 +30,7 @@ async def context() -> StreamFlowContext:
     _context = build_context(
         {
             "database": {
-                "type": "postgresql",
+                "type": "unito.postgresql",
                 "config": {
                     "dbname": os.environ.get("POSTGRES_DB", "streamflow"),
                     "username": os.environ.get("POSTGRES_USER", "streamflow"),


### PR DESCRIPTION
As explained in the StreamFlow documentation, prepending an organization prefix to the plugin and extensio nnames helps avoiding name clahes among different plugins. This commit adheres to that best practice.