### PR TITLE
Fix streamflow version to 0.2.0.dev5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 aiopg==1.4.0
 psycopg2==2.9.6
-streamflow>=0.2.0.dev5
+streamflow==0.2.0.dev5


### PR DESCRIPTION
This commit fixes the StreamFlow version to 0.2.0.dev5, in order to avoid incompatibilities due to changes in the `Database` interface.