### PR TITLE
Fix Mac OS CI steps

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -75,7 +75,7 @@ jobs:
         with:
           node-version: "15"
       - name: "Install Docker (MacOs X)"
-        uses: douglascamata/setup-docker-macos-action@v1-alpha.6
+        uses: douglascamata/setup-docker-macos-action@v1-alpha.9
         if: ${{ startsWith(matrix.on, 'macos-') }}
       - uses: docker/setup-qemu-action@v2
       - name: "Start PostgreSQL Docker container"


### PR DESCRIPTION
As per issue lima-vm/lima#1742, the QEMU 8.1.0 Homebrew package is broken on Intel architectures. This commit upgrades the `douglascamata/setup-docker-macos-action` to version `v1-alpha.9` to overcome this issue.