### PR TITLE
Migrate from aiopg to asyncpg

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ Repository = "https://github.com/alpha-unito/streamflow-postgresql"
 [project.entry-points]
 "unito.streamflow.plugin" = {"unito.postgresql" = "streamflow_postgresql.plugin:PostgreSQLStreamFlowPlugin"}
 
-
 [tool.setuptools]
 packages = [
     "streamflow_postgresql"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-aiopg==1.4.0
-psycopg2==2.9.7
+asyncpg==0.28.0
 streamflow==0.2.0.dev8


### PR DESCRIPTION
The `asyncpg` library supports the `async`/`await` programming paradigm offering much better pefrormance than the `aiopg` or `psycopg` alternatives. This commit removes the `aiopg` dependency and migrates the code to the last version of `asyncpg`.