### PR TITLE
Fix Python dependencies conflict in Mac OS CI

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -75,7 +75,7 @@ jobs:
         with:
           node-version: "15"
       - name: "Install Docker (MacOs X)"
-        uses: douglascamata/setup-docker-macos-action@v1-alpha.9
+        uses: douglascamata/setup-docker-macos-action@v1-alpha.10
         if: ${{ startsWith(matrix.on, 'macos-') }}
         env:
           HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1


### PR DESCRIPTION
This commit updates the `douglascamata/setup-docker-macos-action` to version `v1-alpha.10` to prevent conflicting symlink error due to concurrent Python updates (see
douglascamata/setup-docker-macos-action#16).