### PR TITLE
Add `codecov.yml` configuration file

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,12 @@
+codecov:
+  require_ci_to_pass: true
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 0.5%
+    patch:
+      default:
+        target: auto
+        threshold: 0.5%


### PR DESCRIPTION
This commit adds an explicit Codecov configuration file to set up a threshold for project and patch coverage regressions. This avoid spurious detections in dependabot patches.