### PR TITLE
Fix PyPI relase pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,11 @@ jobs:
   pypi:
     name: "Publish on PyPI"
     runs-on: ubuntu-22.04
+    environment:
+      name: pypi
+      url: https://pypi.org/project/streamflow-postgresql
+    permissions:
+      id-token: write
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/checkout@v4
@@ -55,6 +60,3 @@ jobs:
       - name: "Publish package to PyPI"
         uses: pypa/gh-action-pypi-publish@release/v1
         if: ${{ env.PLUGIN_VERSION != env.PYPI_VERSION }}
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
This commit upgrades the PyPI release pipeline to use the new and recommended OIDC authentication path for Trusted Publishers, improving security and removign the need for a dedicated token.
