### PR TITLE
Removed column `output` in `execution` table

### DIFF
--- a/streamflow_postgresql/schemas/postgresql.sql
+++ b/streamflow_postgresql/schemas/postgresql.sql
@@ -49,7 +49,6 @@ CREATE TABLE IF NOT EXISTS execution
     step       INTEGER,
     tag        TEXT,
     cmd        TEXT,
-    output     BYTEA,
     status     INTEGER,
     start_time BIGINT,
     end_time   BIGINT,


### PR DESCRIPTION
This commit removes the column `output` in `execution` table, which it is not used anymore.