### PR TITLE
Drop support for Python 3.8

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
           cache: pip
           cache-dependency-path: |
             requirements.txt
@@ -51,10 +51,10 @@ jobs:
     strategy:
       matrix:
         on: [ "ubuntu-22.04" ]
-        python: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
+        python: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
         include:
           - on: "macos-13"
-            python: "3.12"
+            python: "3.13"
     runs-on: ${{ matrix.on }}
     env:
       POSTGRES_DB: streamflow

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
       - name: "Get local version"
         run: echo "PLUGIN_VERSION=$(cat streamflow_postgresql/version.py | grep -oP '(?<=VERSION = \")(.*)(?=\")')" >> $GITHUB_ENV
       - name: "Get PyPI version"

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ format-check:
 	black --diff --check streamflow_postgresql tests
 
 pyupgrade:
-	pyupgrade --py3-only --py38-plus $(shell git ls-files | grep .py)
+	pyupgrade --py3-only --py39-plus $(shell git ls-files | grep .py)
 
 test:
 	python -m pytest -rs ${PYTEST_EXTRA}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 description = "StreamFlow PostgreSQL plugin"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = {text = "LGPL-3.0-or-later"}
 classifiers = [
     "Development Status :: 3 - Alpha",
@@ -20,10 +20,11 @@ classifiers = [
     "Operating System :: MacOS",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering",
     "Topic :: System :: Distributed Computing",
 ]

--- a/streamflow_postgresql/database.py
+++ b/streamflow_postgresql/database.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import json
-from typing import Any, MutableMapping, MutableSequence
+from typing import Any
+from collections.abc import MutableMapping, MutableSequence
 
 import asyncpg
 from importlib_resources import files

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@ import asyncio
 import os
 import tempfile
 from asyncio import Lock
-from typing import Collection
+from collections.abc import Collection
 
 import pytest
 import pytest_asyncio

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist =
   bandit
   lint
-  py3.{8,9,10,11,12}-unit
+  py3.{9,10,11,12,13}-unit
 skip_missing_interpreters = True
 
 [pytest]
@@ -12,19 +12,19 @@ testpaths = tests
 [testenv]
 allowlist_externals = make
 commands_pre =
-  py3.{8,9,10,11,12}-unit: python -m pip install -U pip setuptools wheel
+  py3.{9,10,11,12,13}-unit: python -m pip install -U pip setuptools wheel
 commands =
-  py3.{8,9,10,11,12}-unit: make coverage-report coverage.xml PYTEST_EXTRA={posargs}
+  py3.{9,10,11,12,13}-unit: make coverage-report coverage.xml PYTEST_EXTRA={posargs}
 deps =
-  py3.{8,9,10,11,12}-unit: -rrequirements.txt
-  py3.{8,9,10,11,12}-unit: -rtest-requirements.txt
+  py3.{9,10,11,12,13}-unit: -rrequirements.txt
+  py3.{9,10,11,12,13}-unit: -rtest-requirements.txt
 description =
-  py3.{8,9,10,11,12}-unit: Run the unit tests
+  py3.{9,10,11,12,13}-unit: Run the unit tests
 passenv =
   CI
   GITHUB_*
 setenv =
-  py3.{8,9,10,11,12}-unit: LC_ALL = C.UTF-8
+  py3.{9,10,11,12,13}-unit: LC_ALL = C.UTF-8
 
 [testenv:bandit]
 commands = bandit -r streamflow_postgresql


### PR DESCRIPTION
This commit drops support for Python 3.8, removes Python 3.8 from the CI/CD pipeline, updates the code to use the new features introduced in Python 3.9, and introduces support for Python 3.13.