### PR TITLE
Added `isort` to CI/CD checks

### DIFF
--- a/.github/codeql/config.yml
+++ b/.github/codeql/config.yml
@@ -10,3 +10,6 @@ query-filters:
   # Reason: false positive on function body ellipsis (issue 11351)
   - exclude:
       id: py/ineffectual-statement
+  # Reason: no support for the TYPE_CHECKING directive (issue 4258)
+  - exclude:
+      id:  py/unsafe-cyclic-import

--- a/Makefile
+++ b/Makefile
@@ -14,9 +14,11 @@ flake8:
 	flake8 streamflow_postgresql tests
 
 format:
+	isort streamflow tests
 	black streamflow_postgresql tests
 
 format-check:
+	isort --check-only streamflow tests
 	black --diff --check streamflow_postgresql tests
 
 pyupgrade:

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,11 +2,5 @@ codecov:
   require_ci_to_pass: true
 coverage:
   status:
-    project:
-      default:
-        target: auto
-        threshold: 0.5%
-    patch:
-      default:
-        target: auto
-        threshold: 0.5%
+    project: off
+    patch: off

--- a/lint-requirements.txt
+++ b/lint-requirements.txt
@@ -1,4 +1,5 @@
 black==25.1.0
 codespell==2.4.1
 flake8-bugbear==24.12.12
+isort==6.0.0
 pyupgrade==3.19.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,3 +54,6 @@ version = {attr = "streamflow_postgresql.version.VERSION"}
 bandit = {file = "bandit-requirements.txt"}
 lint = {file = "lint-requirements.txt"}
 test = {file = "test-requirements.txt"}
+
+[tool.isort]
+profile = "black"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ from collections.abc import Collection
 import pytest
 import pytest_asyncio
 from streamflow.core.context import StreamFlowContext
-from streamflow.core.deployment import DeploymentConfig, LOCAL_LOCATION
+from streamflow.core.deployment import LOCAL_LOCATION, DeploymentConfig
 from streamflow.core.persistence import PersistableEntity
 from streamflow.ext.utils import load_extensions
 from streamflow.main import build_context

--- a/tests/test_cwl_persistence.py
+++ b/tests/test_cwl_persistence.py
@@ -4,12 +4,12 @@ from typing import Any
 
 import pytest
 from ruamel.yaml.scalarstring import DoubleQuotedScalarString, LiteralScalarString
-
 from streamflow.core import utils
 from streamflow.core.context import StreamFlowContext
 from streamflow.core.workflow import Workflow
 from streamflow.cwl.command import CWLCommand, CWLCommandToken
 from streamflow.workflow.step import ExecuteStep
+
 from tests.conftest import save_load_and_test
 
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,5 +1,4 @@
 import pytest
-
 from streamflow.core import utils
 from streamflow.core.context import StreamFlowContext
 from streamflow.core.workflow import Workflow

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -1,13 +1,10 @@
 import posixpath
 
 import pytest
-
-from tests.conftest import get_docker_deployment_config, save_load_and_test
-
 from streamflow.core import utils
 from streamflow.core.config import BindingConfig
 from streamflow.core.context import StreamFlowContext
-from streamflow.core.deployment import LocalTarget, Target, FilterConfig
+from streamflow.core.deployment import FilterConfig, LocalTarget, Target
 from streamflow.core.workflow import Job, Token, Workflow
 from streamflow.workflow.combinator import (
     CartesianProductCombinator,
@@ -32,6 +29,8 @@ from streamflow.workflow.token import (
     ObjectToken,
     TerminationToken,
 )
+
+from tests.conftest import get_docker_deployment_config, save_load_and_test
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This commit adds the `isort` utility to sort `import` statements alphabetically.