### PR TITLE
Use official Docker setup action

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -45,9 +45,9 @@ jobs:
         with:
           node-version: "24"
       - name: "Install Docker (MacOS X)"
-        uses: douglascamata/setup-docker-macos-action@v1
-        with:
-          colima-additional-options: '--mount /private/var/folders:w'
+        uses: docker/setup-docker-action@v4
+        env:
+          LIMA_START_ARGS: '--vm-type=vz --mount-type=virtiofs --mount /private/var/folders:w'
         if: ${{ startsWith(matrix.on, 'macos-') }}
       - uses: docker/setup-qemu-action@v3
         if: ${{ startsWith(matrix.on, 'ubuntu-') }}
@@ -138,10 +138,10 @@ jobs:
         with:
           node-version: "24"
       - name: "Install Docker (MacOs X)"
-        uses: douglascamata/setup-docker-macos-action@v1
+        uses: docker/setup-docker-action@v4
+        env:
+          LIMA_START_ARGS: '--vm-type=vz --mount-type=virtiofs --mount /private/var/folders:w'
         if: ${{ startsWith(matrix.on, 'macos-') }}
-        with:
-          colima-additional-options: '--mount /private/var/folders:w'
       - uses: docker/setup-qemu-action@v3
       - name: "Start PostgreSQL Docker container"
         run: |


### PR DESCRIPTION
This commit substitutes the `douglascamata/setup-docker-macos-action` GitHub Action with the official `docker/setup-docker-action` which now supports Intel-based Mac OS Runners through `lima`.