### PR TITLE
Make dependabot ignore `setuptools` and `wheel`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,6 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: "setuptools"
+      - dependency-name: "wheel"


### PR DESCRIPTION
This commit forces dependabot to ignore updates to `setuptools` and `wheel` packages, as they are not present in the `uv.lock` file and produce Dependabot errors in the GitHub pipeline.